### PR TITLE
Fix conditional in SidekiqIteration::JobRetryPatch

### DIFF
--- a/lib/sidekiq_iteration/job_retry_patch.rb
+++ b/lib/sidekiq_iteration/job_retry_patch.rb
@@ -25,6 +25,6 @@ module SidekiqIteration
   end
 end
 
-if Sidekiq::JobRetry.instance_method(:process_retry)
+if Sidekiq::JobRetry.private_instance_methods.include?(:process_retry)
   Sidekiq::JobRetry.prepend(SidekiqIteration::JobRetryPatch)
 end


### PR DESCRIPTION
Using  `if Sidekiq::JobRetry.instance_method(:process_retry)` will raise a `NameError` exception if the method does not exist and the application will fail to boot. 

This PR changes the conditional to use `if Sidekiq::JobRetry.private_instance_methods.include?(:process_retry)` which will return `true` or `false` instead.