### PR TITLE
Fix storing run metadata when the job fails for sidekiq < 6.5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## master (unreleased)
 
+- Fix storing run metadata when the job fails for sidekiq < 6.5.2
+
 - Make enumerators resume from the last cursor position
 
   This fixes `NestedEnumerator` to work correctly. Previously, each intermediate enumerator


### PR DESCRIPTION
Closes #1.

@mperham Can you please suggest how can I store some additional data to the job when it is retried without the need to override `process_retry` (see this PR changes)? 
Currently, sidekiq directly pushed the failed job to the `retry` queue - https://github.com/mperham/sidekiq/blob/cc2a07d45e8621aaac886290d397968aa2bc2cb6/lib/sidekiq/job_retry.rb#L187-L189
Or I am missing something?